### PR TITLE
feat: add world_name placeholder

### DIFF
--- a/src/main/java/org/allaymc/papi/PlaceholderAPI.java
+++ b/src/main/java/org/allaymc/papi/PlaceholderAPI.java
@@ -157,6 +157,7 @@ public class PlaceholderAPI extends Plugin {
         registerPlaceholder(this, "is_gliding", (player, params) -> String.valueOf(player.isGliding()));
         registerPlaceholder(this, "dimension", (player, params) -> player.getLocation().dimension().getDimensionInfo().toString());
         registerPlaceholder(this, "dimension_id", (player, params) -> String.valueOf(player.getLocation().dimension().getDimensionInfo().dimensionId()));
+        registerPlaceholder(this, "world_name", (player, params) -> player.getWorld().getWorldData().getDisplayName());
         registerPlaceholder(this, "ping", checkActualPlayer((player, params) -> String.valueOf(player.getController().getPing())));
         registerPlaceholder(this, "mc_version", checkActualPlayer((player, params) -> player.getController().getLoginData().getGameVersion()));
         registerPlaceholder(this, "online", (player, params) -> String.valueOf(Server.getInstance().getPlayerManager().getPlayerCount()));


### PR DESCRIPTION
Add a new default placeholder {world_name} that returns the display name of the world the player is currently in.